### PR TITLE
refactor: use xslt1 for queryBinding and reorder L000 schematron phase

### DIFF
--- a/lib/buildingElements.sch
+++ b/lib/buildingElements.sch
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt1">
   <ns prefix="auc" uri="http://buildingsync.net/schemas/bedes-auc/2019"/>
 <!--  For logic pertaining to a Building element. -->
   

--- a/lib/floorAreaTests.sch
+++ b/lib/floorAreaTests.sch
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt1">
 <!--  
     For logic pertaining to FloorArea elements.  Parent passed should be auc:FloorAreas,
     context can be anywhere ref="auc:FloorAreas"

--- a/lib/rootElements.sch
+++ b/lib/rootElements.sch
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt1">
   <ns prefix="auc" uri="http://buildingsync.net/schemas/bedes-auc/2019"/>
   
   <!--    

--- a/lib/scenarioElements.sch
+++ b/lib/scenarioElements.sch
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt1">
   <ns prefix="auc" uri="http://buildingsync.net/schemas/bedes-auc/2019"/>
 <!--  
     For logic that pertains to Scenario elements

--- a/lib/siteBuildingElements.sch
+++ b/lib/siteBuildingElements.sch
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt1">
   <ns prefix="auc" uri="http://buildingsync.net/schemas/bedes-auc/2019"/>
 <!--  
     For logic that pertains to either a Site OR a Building element.  

--- a/tests/schema2.0.0-pr2/Level_000/BuildingSync_schematron_L000.sch
+++ b/tests/schema2.0.0-pr2/Level_000/BuildingSync_schematron_L000.sch
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt1">
   <ns prefix="auc" uri="http://buildingsync.net/schemas/bedes-auc/2019"/>
-  <include href="../../../lib/rootElements.sch#root.oneOfEachUntilBuilding"/>
-  <include href="../../../lib/rootElements.sch#root.oneOfEachFacilityUntilScenario"/>
-  <include href="../../../lib/siteBuildingElements.sch#sbe.cityStateOrClimateZone"/>
-  <include href="../../../lib/scenarioElements.sch#sc.baseline"/>
-  <include href="../../../lib/buildingElements.sch#be.L000"/>
-  <include href="../../../lib/floorAreaTests.sch#fa.oneGrossType"/>
-  <include href="../../../lib/floorAreaTests.sch#fa.haveTypeAndValue"/>
-  
 <!--  L000 -->
   <phase id="L000AuditRequirements">
     <active pattern="root.oneOfEachUntilBuilding"/>
@@ -27,7 +19,14 @@
     <active pattern="be.fa.haveTypeAndValue"/>
     <active pattern="be.fa.oneGrossFloorArea"/>
   </phase>
-  
+
+  <include href="../../../lib/rootElements.sch#root.oneOfEachUntilBuilding"/>
+  <include href="../../../lib/rootElements.sch#root.oneOfEachFacilityUntilScenario"/>
+  <include href="../../../lib/siteBuildingElements.sch#sbe.cityStateOrClimateZone"/>
+  <include href="../../../lib/scenarioElements.sch#sc.baseline"/>
+  <include href="../../../lib/buildingElements.sch#be.L000"/>
+  <include href="../../../lib/floorAreaTests.sch#fa.oneGrossType"/>
+  <include href="../../../lib/floorAreaTests.sch#fa.haveTypeAndValue"/>
 <!--  Instantiate abstract patterns for L000 use case -->
   <pattern id="be.fa.haveTypeAndValue" is-a="fa.haveTypeAndValue">
     <param name="parent" value="auc:Building/auc:FloorAreas"/>

--- a/tests/schema2.0.0-pr2/Level_000/BuildingSync_schematron_L000.xml
+++ b/tests/schema2.0.0-pr2/Level_000/BuildingSync_schematron_L000.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt1">
   <sch:title>Level 100 schema</sch:title>
   <sch:ns prefix="auc" uri="http://buildingsync.net/schemas/bedes-auc/2019"/>
   


### PR DESCRIPTION
### Changes
- (non-breakig): use xslt1 for queryBinding in lib (lxml isoschematron only allows xslt1)
- reorder the elements of L000 schematron file (lxml isoschematron expects them to be in this order)

### Note
- This refactoring is due to using lxml with the selection-tool
